### PR TITLE
Added necessary classes and functions for WireframeMaterial

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -1,5 +1,8 @@
 export * from "./materials/MeshNormalDepthMaterial";
 export * from "./materials/MeshRGBADepthMaterial";
 export * from "./materials/MeshViewPositionMaterial";
+export * from "./materials/MeshWireframeMaterial";
 export * from "./materials/MeshWorldNormalMaterial";
 export * from "./materials/MeshWorldPositionMaterial";
+
+export * from "./utils/BufferGeometryUtils";

--- a/src/materials/MeshWireframeMaterial.js
+++ b/src/materials/MeshWireframeMaterial.js
@@ -1,0 +1,92 @@
+import { ShaderLib, ShaderMaterial, UniformsUtils } from 'three';
+
+var vertexShader = [
+    "attribute vec3 barycentric;",
+
+    "varying vec3 vTestNormal;",
+    "varying vec3 vPosition;",
+    "varying vec3 vBarycentric;",
+
+    "void main()",
+    "{",
+
+    "   vec3 vNormal = normalize(normalMatrix * normal);",
+
+    "   vPosition = position;",
+    "   vTestNormal = normal;",
+    "   vBarycentric = barycentric;",
+
+    "   gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);",
+    "}"
+].join("\n");
+
+var fragmentShader = [
+    "uniform float opacity;",
+    "uniform float lineWidth;",
+    "uniform vec3 color;",
+    "uniform vec3 lineColor;",
+
+    "varying vec3 vTestNormal;",
+    "varying vec3 vPosition;",
+    "varying vec3 vBarycentric;",
+
+    "#ifdef GL_OES_standard_derivatives",
+    "   float edgeFactor(vec3 vBarycentric){                 ",
+    "       vec3 d = lineWidth*fwidth(vBarycentric);                 ",
+    "       vec3 a3 = smoothstep(vec3(0.0), d, vBarycentric);   ",
+    "       return min(min(a3.x, a3.y), a3.z);             ",
+    "   }",
+    "#endif",
+
+    "void main()",
+    "{",
+    "#ifdef GL_OES_standard_derivatives",
+    "    gl_FragColor = mix(vec4(lineColor,1.0), vec4(color,opacity), edgeFactor(vBarycentric)); ",
+    "#else",
+    "   if(any(lessThan(vBarycentric, vec3(0.02)))){",
+    "       gl_FragColor = vec4(lineColor,1.0);",
+    "   }",
+    "   else{",
+    "       gl_FragColor = vec4(color,opacity);",
+    "   }",
+    "#endif",
+    "}"
+].join("\n");
+
+
+class MeshWireframeMaterial extends ShaderMaterial {
+    constructor(parameters) {
+        super({
+            uniforms: UniformsUtils.merge([
+                ShaderLib.normal.uniforms,
+                {
+                    opacity: {
+                        type: 'f',
+                        value: parameters.opacity
+                    },
+                    lineWidth: {
+                        type: 'f',
+                        value: parameters.lineWidth
+                    },
+                    color: {
+                        type: 'c',
+                        value: parameters.color
+                    },
+                    lineColor: {
+                        type: 'c',
+                        value: parameters.lineColor
+                    }
+                }
+            ]),
+            vertexShader: vertexShader,
+            fragmentShader: fragmentShader,
+        });
+
+        this.extensions.derivatives = true;
+        this.opacity = parameters.opacity;
+        this.transparent = parameters.opacity !== 1.0;
+        this.side = parameters.side;
+    }
+}
+
+export { MeshWireframeMaterial }

--- a/src/utils/BufferGeometryUtils.js
+++ b/src/utils/BufferGeometryUtils.js
@@ -1,0 +1,39 @@
+import { BufferAttribute, InterleavedBufferAttribute, GLBufferAttribute } from 'three';
+
+/**
+ * Add "baricentric coordinates", with actually means uv per triangle.
+ * Those are used as vaying in shaders to know where we are exactly on the currently rendered triangle.
+ * It is used, for example, to create nice and smooth wirframe render.
+ * @param {import('three').BufferGeometry} geometry
+ */
+function computeVertexBarycentricCoordinates(geometry) {
+    if (geometry.getIndex() !== null) {
+        throw "Error : cannot add barycentric coordinates on indexed geometry. Please call toNonIndexed first.";
+    }
+
+    const nVertices = geometry.getAttribute("position")?.count;
+
+    let bar = geometry.getAttribute("barycentric");
+    if (bar === undefined) {
+        geometry.addAttribute("barycentric", new Float32Array(nVertices * 3), 3);
+    }
+    bar = geometry.getAttribute("barycentric");
+
+    if (!(bar instanceof BufferAttribute)) {
+        throw "Error: cannot compute barycentric coordinates as the barycentric attribute is not a BufferAttribute. Other types are not supported (yet).";
+    }
+
+    // In this case we build the content of barycenter coordinates
+    const kn = bar.count;
+    for (let k = 0; k < kn; k += 3) {
+        bar.setXYZ(k, 1, 0, 0);
+        bar.setXYZ(k + 1, 0, 1, 0);
+        bar.setXYZ(k + 2, 0, 0, 1);
+    }
+
+    return geometry;
+}
+
+export {
+    computeVertexBarycentricCoordinates
+}


### PR DESCRIPTION
Untested but this should be the necessary code for rendering wireframe nicely.

@typhomnt I'm not sure it would work well with the SMAO algorithm as it may not respect what you recently setup in the material switcher.

We could probably improve it by using three.js shaderchunk and just adding the triangle drawing by overwriting the color. However I don't think it's worth the effort now.

Note that this rendering will require deindexing of the geometry, which must then have all its other attributes computed (especially normals).